### PR TITLE
Create a csv file for measurements details

### DIFF
--- a/xamsl_measurements.csv
+++ b/xamsl_measurements.csv
@@ -1,0 +1,3 @@
+run,pmt_bottom_voltage [V],pmt_top_voltage [V],Notes
+282,-850V,-850V,Gas phase
+283,-850V,-850V,Gas/Liquid transition phase


### PR DESCRIPTION
This file is meant to contain informations about xamsl runs that are not stored in the MongoDB and that can be easily loaded during the analysis by using the package amstrax_files.
This is just an example but I will update it to contain all the xamsl runs. 