### PR TITLE
debugged 2 params

### DIFF
--- a/corrections/_global/_global_v2.json
+++ b/corrections/_global/_global_v2.json
@@ -1,0 +1,19 @@
+{
+    "elife": "elife_v1.json",
+    "gain_to_pe_array": "gain_to_pe_array_v1.json",
+    "pos_rec_params": "pos_rec_params_v0.json",
+    "s1_map": "s1_map_v0.json",
+
+    "s1_min_area": 1,
+    "s2_min_area": 100,
+    "s2_min_width": 600,
+    "s1_max_width": 140,
+    "s1_max_area_fraction_top": 1,
+    "s1_min_channels": 1,
+    "s2_min_channels": 1,
+    "left_event_extension": 50000,
+    "right_event_extension": 50000,
+    "max_drift_length": 52,
+    "electron_drift_velocity": 0.00104,
+    "electron_drift_time_gate": 5000
+}


### PR DESCRIPTION
Fixed a bug with the electron drift velocity. Because we had max_drift_length = 10 and electron_drift_velocity = 0.0015, it yielded a max_drift_time of 10 / 0.0015 = 6667ns, whereas the max drift time is 39.5us. Set max_drift_length to 52 (depth of TPC) and the electron_drift_velocity accordingly so we get a max_drift_time of 50us (a bit of margin).